### PR TITLE
[BIG-1889] fix for global timeout and introduce query timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ cover/
 .cache/
 *.iml
 /scripts/.thrift_gen
+build/

--- a/pyhive/hive.py
+++ b/pyhive/hive.py
@@ -161,6 +161,7 @@ class Connection(object):
         ssl_cert=None,
         thrift_transport=None,
         timeout=None,
+        query_timeout=None,
         thrift_keepalive=False
     ):
         """Connect to HiveServer2
@@ -282,6 +283,7 @@ class Connection(object):
             self._sessionHandle = response.sessionHandle
             assert response.serverProtocolVersion == protocol_version, \
                 "Unable to handle protocol version {}".format(response.serverProtocolVersion)
+            socket.setTimeout(query_timeout)
             with contextlib.closing(self.cursor()) as cursor:
                 cursor.execute('USE `{}`'.format(database))
         except:


### PR DESCRIPTION
Why?
----
- we were having global timeout which was causing query to fail after timeout 

How?
----
- we override the timeout value with query timeout once we get the connection. default value of query timeout is None so it will be same behaviour as before


Deployment Steps
----------------
- merge into thrift-keepalive
- get the commit ID
- raise Another PR in ntropy to change the commit it

Deployment Verification
-----------------------
- merge the PR
